### PR TITLE
Integrate Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ All notable changes to this project will be documented in this file.
 - README now links to `docs/json-format.md` and weist auf `.env.example` hin.
 - CI lädt Testabdeckung als Artefakt hoch und führt `npx snyk test` aus.
 - Added Python tooling (Black, Flake8, Ruff) to pre-commit configuration.
+- Dependabot prüft nun npm-Abhängigkeiten und GitHub-Actions-Workflows;
+  zugehörige Pull Requests laufen durch die CI.
 - CI caches npm and pre-commit directories and uploads Railway logs as artifact.
 - Added `LOG_ROTATION_INTERVAL` and `LOG_MAX_SIZE` environment variables with
   matching documentation and `.env.example` entries.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ ausgeführt und als `latest_railway.log` hochgeladen. Zusätzlich wird die
 Testabdeckung als Artefakt bereitgestellt und temporäre Verzeichnisse
 (`tmp-repo-*`) werden automatisch entfernt.
 
+## Automatische Updates
+
+Dependabot überprüft wöchentlich die npm-Abhängigkeiten und GitHub-Actions-
+Workflows. Sicherheitsupdates und Warnungen werden direkt über GitHub
+bereitgestellt, Pull Requests laufen automatisch durch die CI-Pipeline.
+
 ## Lizenz
 
 Dieses Projekt steht unter der [MIT-Lizenz](LICENSE). Es verwendet Daten aus

--- a/tests/dependabot-config.test.ts
+++ b/tests/dependabot-config.test.ts
@@ -1,0 +1,9 @@
+import fs from 'fs';
+
+describe('dependabot config', () => {
+  it('contains npm and GitHub Actions updates', () => {
+    const content = fs.readFileSync('.github/dependabot.yml', 'utf-8');
+    expect(content).toContain('package-ecosystem: npm');
+    expect(content).toContain('package-ecosystem: github-actions');
+  });
+});


### PR DESCRIPTION
## Summary
- configure Dependabot for npm and GitHub Actions
- document automatic dependency updates
- note Dependabot in changelog
- add a small unit test to check config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685becd2bdb8832f843bde6a64e58e9a