### PR TITLE
Add coverage threshold enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files
-      - run: npm test
+      - run: npm test -- --coverage
       - run: |
           mkdir -p logs
           npx railway logs --service "$RAILWAY_SERVICE" --environment "$RAILWAY_ENV" --follow > logs/latest_railway.log &

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ npm run format
 npm test
 ```
 
+Die Testabdeckung muss global mindestens 80 % betragen (Statements,
+Branches, Functions und Lines). Unterschreitet ein Pull Request diesen
+Wert, bricht die CI-Pipeline ab.
+
 Installiere optional die Git-Hooks per `pre-commit install`, um die
 Format- und Lint-Prüfungen (Prettier/ESLint) automatisch vor jedem Commit
 auszuführen. Python-Linter sind nicht mehr enthalten;
@@ -123,8 +127,8 @@ Prettier/ESLint), Tests und einen `npx snyk test`-Scan aus.
 Abhängigkeiten und Pre-commit-Umgebungen werden über `actions/cache`
 zwischengespeichert. Nach dem Lauf wird `railway logs --follow`
 ausgeführt und als `logs/latest_railway.log` hochgeladen. Zusätzlich wird die
-Testabdeckung als Artefakt bereitgestellt und temporäre Verzeichnisse
-(`tmp-repo-*`) werden automatisch entfernt.
+Testabdeckung (mindestens 80 %) als Artefakt bereitgestellt und temporäre
+Verzeichnisse (`tmp-repo-*`) werden automatisch entfernt.
 
 ## Automatische Updates
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,12 @@ module.exports = {
   testMatch: ['**/tests/**/*.test.ts'],
   collectCoverage: true,
   coverageDirectory: 'coverage',
+  coverageThreshold: {
+    global: {
+      statements: 80,
+      branches: 80,
+      functions: 80,
+      lines: 80,
+    },
+  },
 };


### PR DESCRIPTION
## Summary
- enforce coverage threshold in Jest config
- fail CI when coverage is insufficient
- document coverage requirement in README

## Testing
- `pre-commit run --files jest.config.js README.md .github/workflows/ci.yml`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_685c76fed0f0832faa82a1d0866b2ecd