### PR TITLE
Add Python linting and security hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20.x
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
       - uses: actions/cache@v4
         with:
           path: ~/.npm

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ coverage/
 
 # Local clone of tcgdex/cards-database
 tcgdex/
+
+# Python cache
+__pycache__/
+*.pyc
+
+# Environment files
+.env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,28 @@
 repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.9
+    hooks:
+      - id: ruff
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.9.0
+    hooks:
+      - id: pip-audit
+        additional_dependencies: ["pip-audit[cyclonedx]", "cyclonedx-bom"]
+        args: ["-r", "requirements.txt", "--format", "columns"]
   - repo: local
     hooks:
       - id: prettier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 - CI workflow uploads logs as an artifact and cleans the `logs/` directory.
 
 - Allow running on Node.js 20 or newer.
+- Added Python-based linting hooks (Black, Flake8, Ruff) and `pip-audit`
+  via Pre-commit.
 - Updated documentation and tests.
 - Improved path validation and error handling in export script.
 - Export script now throws errors instead of exiting directly.

--- a/README.md
+++ b/README.md
@@ -115,15 +115,16 @@ Die Testabdeckung muss global mindestens 80 % betragen (Statements,
 Branches, Functions und Lines). Unterschreitet ein Pull Request diesen
 Wert, bricht die CI-Pipeline ab.
 
-Installiere optional die Git-Hooks per `pre-commit install`, um die
-Format- und Lint-Prüfungen (Prettier/ESLint) automatisch vor jedem Commit
-auszuführen. Python-Linter sind nicht mehr enthalten;
-die Hooks prüfen lediglich Formatierung und TypeScript-Codestil.
+Installiere optional die Git-Hooks per `pre-commit install`, um Format-
+und Lint-Prüfungen automatisch vor jedem Commit auszuführen. Neben
+Prettier und ESLint laufen dabei auch die Python-Linter **Black**,
+**Flake8** und **Ruff** sowie `pip-audit`.
 
 ## Continuous Integration
 
-Die GitHub-Actions führen Linting, Pre-commit-Prüfungen (nur
-Prettier/ESLint), Tests und einen `npx snyk test`-Scan aus.
+Die GitHub-Actions führen Linting, Pre-commit-Prüfungen (Prettier,
+ESLint, Black, Flake8, Ruff und `pip-audit`), Tests und einen
+`npx snyk test`-Scan aus.
 Abhängigkeiten und Pre-commit-Umgebungen werden über `actions/cache`
 zwischengespeichert. Nach dem Lauf wird `railway logs --follow`
 ausgeführt und als `logs/latest_railway.log` hochgeladen. Zusätzlich wird die

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pre-commit
+pip-audit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# No Python runtime dependencies


### PR DESCRIPTION
## Summary
- integrate Black, Flake8, Ruff and pip-audit via pre-commit
- add Python setup and caching to CI
- ignore Python build artefacts and `.env`
- document new linting in README and CHANGELOG
- provide requirements-dev and blank requirements.txt

## Testing
- `pre-commit run --files README.md CHANGELOG.md .gitignore .github/workflows/ci.yml .pre-commit-config.yaml requirements-dev.txt requirements.txt`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c1b5b7edc832f8dcbf58cf3db5c19