### PR TITLE
Add daily Dependabot for Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ All notable changes to this project will be documented in this file.
 - Added Python tooling (Black, Flake8, Ruff) to pre-commit configuration.
 - Dependabot prüft nun npm-Abhängigkeiten und GitHub-Actions-Workflows;
   zugehörige Pull Requests laufen durch die CI.
+- Dependabot überwacht jetzt zusätzlich die Python-Abhängigkeiten täglich;
+  entsprechende Pull Requests durchlaufen die komplette CI mit Tests,
+  Linting und `pip-audit`.
 - CI caches npm and pre-commit directories and uploads Railway logs as artifact.
 - Added `LOG_ROTATION_INTERVAL` and `LOG_MAX_SIZE` environment variables with
   matching documentation and `.env.example` entries.

--- a/README.md
+++ b/README.md
@@ -133,9 +133,10 @@ Verzeichnisse (`tmp-repo-*`) werden automatisch entfernt.
 
 ## Automatische Updates
 
-Dependabot überprüft wöchentlich die npm-Abhängigkeiten und GitHub-Actions-
-Workflows. Sicherheitsupdates und Warnungen werden direkt über GitHub
-bereitgestellt, Pull Requests laufen automatisch durch die CI-Pipeline.
+Dependabot überwacht wöchentlich die npm-Abhängigkeiten und GitHub-Actions-
+Workflows und prüft die Python-Abhängigkeiten täglich. Alle automatisch
+erzeugten Pull Requests laufen durch die komplette CI mit Linting,
+Tests und `pip-audit`.
 
 ## Lizenz
 


### PR DESCRIPTION
## Summary
- expand Dependabot to monitor Python requirements daily
- document Dependabot update process
- note Python updates in changelog

## Testing
- `pre-commit run --files README.md CHANGELOG.md .github/dependabot.yml`
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c8221cdd8832f90220eb0724a93c9