### PR TITLE
Fix Snyk step condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
           RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE || '' }}
           RAILWAY_ENV: ${{ secrets.RAILWAY_ENV || '' }}
       - name: Snyk Test
-        if: ${{ secrets.SNYK_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository }}
-        run: snyk test
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        if: github.event.pull_request.head.repo.full_name == github.repository && env.SNYK_TOKEN != ''
+        run: snyk test
       - uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,21 @@
+name: Security
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  snyk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - run: npm ci
+      - name: Snyk Test
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        if: github.event.pull_request.head.repo.full_name == github.repository && env.SNYK_TOKEN != ''
+        run: npx snyk test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,3 +70,4 @@ All notable changes to this project will be documented in this file.
 - CI installs Python runtime requirements so structlog is available.
 - README lists `pip install -r requirements.txt` during setup.
 - CI: Skip Snyk test in forked PRs to prevent missing-secret auth errors.
+- CI: Guard Snyk steps with env variable to handle missing secrets gracefully.

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ Prettier und ESLint laufen dabei auch die Python-Linter **Black**,
 Die GitHub-Actions führen Linting, Pre-commit-Prüfungen (Prettier,
 ESLint, Black, Flake8, Ruff und `pip-audit`), Tests und einen
 `npx snyk test`-Scan aus. Da Secrets in Pull Requests von Forks nicht
-verfügbar sind, läuft dieser Schritt nur, wenn das `SNYK_TOKEN`-Secret
-gesetzt ist und der PR aus demselben Repository stammt. So verhindern
-wir Authentifizierungsfehler.
+verfügbar sind, wird das Token über eine Umgebungsvariable gesetzt und
+der Schritt nur ausgeführt, wenn der PR aus demselben Repository stammt
+und das Token vorhanden ist. So verhindern wir Authentifizierungsfehler.
 Abhängigkeiten und Pre-commit-Umgebungen werden über `actions/cache`
 zwischengespeichert. Nach dem Lauf wird `railway logs --follow`
 ausgeführt und als `logs/latest_railway.log` hochgeladen. Zusätzlich wird die


### PR DESCRIPTION
## Summary
- fix conditional Snyk step in CI workflow
- add standalone security workflow with corrected token guard
- document new behaviour in README and CHANGELOG

## Testing
- `npm test`
- `pytest --cov=. --cov-report=term-missing`
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/security.yml README.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_685d274e8cfc832f9cede25a23e4613d