### PR TITLE
Fix Snyk scan and document SNYK_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,6 @@ LOG_MAX_SIZE=
 
 # Print first 500 characters of output after export when set
 DEBUG=
+
+# Token for Snyk security scans
+SNYK_TOKEN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,13 @@ jobs:
         env:
           RAILWAY_SERVICE: ${{ secrets.RAILWAY_SERVICE || '' }}
           RAILWAY_ENV: ${{ secrets.RAILWAY_ENV || '' }}
+      - name: Install Snyk CLI
+        run: npm install -g snyk
       - name: Snyk Test
-        if: ${{ secrets.SNYK_TOKEN != '' && github.event.pull_request.head.repo.full_name == github.repository }}
-        run: snyk test
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        if: ${{ env.SNYK_TOKEN != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+        run: snyk test
       - uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ All notable changes to this project will be documented in this file.
 - CI runs `npm audit --production` and pre-commit checks.
 - `.nvmrc` added to pin Node version locally.
 - README now links to `docs/json-format.md` and weist auf `.env.example` hin.
-- CI lädt Testabdeckung als Artefakt hoch und führt `npx snyk test` aus.
+- CI lädt Testabdeckung als Artefakt hoch und führt `snyk test` aus.
 - Added Python tooling (Black, Flake8, Ruff) to pre-commit configuration.
 - Dependabot prüft nun npm-Abhängigkeiten und GitHub-Actions-Workflows;
   zugehörige Pull Requests laufen durch die CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ npm test
 # Testabdeckung wird automatisch erzeugt und im Ordner `coverage/` abgelegt
 ```
 
-Der CI-Workflow prüft zusätzlich die Abhängigkeiten mit `npx snyk test` und
+Der CI-Workflow prüft zusätzlich die Abhängigkeiten mit `snyk test` und
 stellt die Coverage als Artefakt bereit.
 
 Installiere optional die Git-Hooks mit

--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ Prettier und ESLint laufen dabei auch die Python-Linter **Black**,
 
 Die GitHub-Actions führen Linting, Pre-commit-Prüfungen (Prettier,
 ESLint, Black, Flake8, Ruff und `pip-audit`), Tests und einen
-`npx snyk test`-Scan aus. Da Secrets in Pull Requests von Forks nicht
-verfügbar sind, läuft dieser Schritt nur, wenn das `SNYK_TOKEN`-Secret
-gesetzt ist und der PR aus demselben Repository stammt. So verhindern
-wir Authentifizierungsfehler.
+`snyk test`-Scan aus. Vor dem Scan wird das Snyk-CLI installiert.
+Da Secrets in Pull Requests von Forks nicht verfügbar sind, läuft
+dieser Schritt nur, wenn das `SNYK_TOKEN`-Secret gesetzt ist und der
+PR nicht aus einem Fork stammt. So verhindern wir
+Authentifizierungsfehler.
 Abhängigkeiten und Pre-commit-Umgebungen werden über `actions/cache`
 zwischengespeichert. Nach dem Lauf wird `railway logs --follow`
 ausgeführt und als `logs/latest_railway.log` hochgeladen. Zusätzlich wird die


### PR DESCRIPTION
## Summary
- install and guard Snyk CLI usage in CI
- document Snyk scan behaviour in docs
- add `SNYK_TOKEN` placeholder to `.env.example`

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md CONTRIBUTING.md CHANGELOG.md .env.example`
- `npm test`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d2e9413fc832fa54b0798bce19d0d